### PR TITLE
Fix failure on Java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <targetJdk>1.6</targetJdk>
     <groovy.version>2.0.7</groovy.version>
     <spock.version>0.7-groovy-2.0</spock.version>
-    <spring.version>3.1.1.RELEASE</spring.version>
+    <spring.version>4.1.6.RELEASE</spring.version>
     <jetty.version>8.1.15.v20140411</jetty.version>
   </properties>
 


### PR DESCRIPTION
On Java8 there were issues `type mismatch between read and write methods`
for one of the test classes. According to https://jira.spring.io/browse/SPR-12448
the issue is in Spring and it was fixed somewhere in 4.x versions. So
Spring version was updated to the latest: 4.1.6.

The change is tested on Java: 6u6, 7u75, 8u40.
